### PR TITLE
Fixes while condition to avoid error with R (>4.2)

### DIFF
--- a/R/mc_hierarchy.r
+++ b/R/mc_hierarchy.r
@@ -105,7 +105,7 @@ mcell_mc_hierarchy = function(mc_id, mc_hc, T_gap)
 	for(i in which(gaps > T_gap)) {
 		j = parent[i]
 		mincells = cells[i] + n_min_outcells
-		while(j != -1 & cells[j] < mincells) {
+		while(j != -1 && cells[j] < mincells) {
 			j = parent[j]	
 		}
 		if(j != -1) { 


### PR DESCRIPTION
Implements recommended fix in #84. Issue arises because in R 4.2.0 release news: "Calling if() or while() with a condition of length greater than one gives an error rather than a warning". 

In previous versions of R multiple condition in a while would result in a warning and only evaluate the first element. This has been deprecated and will now result in an error, a short circuit && ensures that only the first element is evaluated and avoids an error.