### PR TITLE
Fix scm_downsamp silently dropping tail cells (#96)

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -43,7 +43,7 @@ scm_downsamp = function(umis, n)
 	max_bin = min(max_bin, ceiling(ncol(umis)/500))
 
 	if(max_bin*10000 < ncol(umis)) {
-		max_bin =  round(ncol(umis))/10000
+		max_bin = ceiling(ncol(umis)/10000)   # ponytail: ceiling, not round(ncol)/10000 -> that gave a non-integer bin count that dropped tail cells (#96)
 	}
 	cell_quant = ceiling(ncol(umis)/max_bin)
 	seed = 19
@@ -61,6 +61,9 @@ scm_downsamp = function(umis, n)
 		message("parallel downsampling incomplete (", ncol(umis_ds), "/", ncol(umis), " cells), retrying sequentially")
 		res <- plyr::alply(1:max_bin, 1, sub_dsamp, .parallel=FALSE)
 		umis_ds = do.call(cbind, res)
+	}
+	if(ncol(umis_ds) != ncol(umis)) {
+		stop("scm_downsamp dropped cells (", ncol(umis_ds), "/", ncol(umis), ") - refusing to return an incomplete matrix")
 	}
 
 	.restore_seed(old_seed)


### PR DESCRIPTION
`scm_downsamp()` computed `max_bin <- round(ncol(umis))/10000` - a no-op round then division, yielding a non-integer (e.g. 10.5393 for 105,393 cells). `1:max_bin` truncates to `1:10`, so only 10 bins ran while `cell_quant` stayed at 10000, covering 100,000 cells and silently dropping the last 5,393. Downstream `gset_get_feat_mat(..., add_non_dsamp = TRUE)` then failed with "subscript out of bounds".

Fix:
- `max_bin = ceiling(ncol(umis)/10000)` - integer bin count that always covers every cell.
- Hard-`stop()` after the sequential retry if any cell is still missing, so an incomplete matrix is never returned silently.

Verified the exact issue case (105,393 cells / 4 cores) dropped 5,393 cells before and covers 100% after; also checked large (1M), tiny, and boundary inputs.

Closes #96

https://claude.ai/code/session_01PJZZGJqeRZyJGxW51ki7Jo