### PR TITLE
Fix OOM in scm_gene_stat on large datasets (#98)

### DIFF
--- a/R/gstats.r
+++ b/R/gstats.r
@@ -110,15 +110,15 @@ scm_gene_stat = function(mat_id,
 	n = ncol(mat)
 	stat_on_genes = function(i) {
 		g_i = (1+(i-1)*quant):(min(nrow(mat_fg),i*quant))
-		mat_gi = as.matrix(mat_fg[g_i,])
-		mat_ds_gi = as.matrix(mat_ds[g_i,])
+		mat_gi = as.matrix(mat_fg[g_i,,drop=FALSE])
+		mat_ds_gi = as.matrix(mat_ds[g_i,,drop=FALSE])
 		gstat = data.frame(stringsAsFactors = F,
 	   	name = rownames(mat_gi),
 			tot = rowSums(mat_gi),
 			var = round(matrixStats::rowVars(mat_gi),7),
 			niche_stat =
 		  		apply(mat_gi, 1, quant_mean, k_reg = 10),
-			n_mean = round(matrixStats::rowMeans2(as.matrix(mat_n[g_i,])),7),
+			n_mean = round(matrixStats::rowMeans2(as.matrix(mat_n[g_i,,drop=FALSE])),7),
 			ds_top1 = matrixStats::rowMaxs(mat_ds_gi) ,
 			ds_top2 = matrixStats::rowOrderStats(mat_ds_gi, which = n_ds-1) ,
 			ds_top3 = matrixStats::rowOrderStats(mat_ds_gi, which = n_ds-2) ,
@@ -128,9 +128,10 @@ scm_gene_stat = function(mat_id,
 			ds_mean = round(matrixStats::rowMeans2(mat_ds_gi),7))
 		return(gstat)
 	}
-	max_bin = get_param("mc_cores")
-	doMC::registerDoMC(max_bin)
-	quant = ceiling(nrow(mat_fg)/max_bin)
+	doMC::registerDoMC(get_param("mc_cores"))
+	# ponytail: ~50MB per dense block; quant=nrow/mc_cores densified multi-GiB per fork
+	quant = max(1L, floor(5e7/(8*n)))
+	max_bin = ceiling(nrow(mat_fg)/quant)
 
 	res <- plyr::alply(1:max_bin, 1, stat_on_genes, .parallel=TRUE)
 	gene_stat = do.call(rbind, res)
@@ -138,17 +139,17 @@ scm_gene_stat = function(mat_id,
 		message("parallel gstat computation incomplete (", nrow(gene_stat), "/", nrow(mat_fg), " genes), retrying sequentially")
 		res <- plyr::alply(1:max_bin, 1, stat_on_genes, .parallel=FALSE)
 		gene_stat = do.call(rbind, res)
+		if(nrow(gene_stat) != nrow(mat_fg)) {
+			stop("MCERR - gstat computation incomplete after sequential retry (", nrow(gene_stat), "/", nrow(mat_fg), " genes)")
+		}
 	}
 	message("done computing basic gstat, will compute trends")
 
 	if(ncol(mat) > 50000) {
 		subs = sample(1:ncol(mat),50000)
-		ctot = colSums(mat[,subs])
-		gene_stat$sz_cor = round(apply(mat_fg[,subs], 1, function(x) { cor(x, ctot) }),3)
-
+		gene_stat$sz_cor = round(.sparse_row_cor(mat_fg[,subs], colSums(mat[,subs])),3)
 	} else {
-		ctot = colSums(mat)
-		gene_stat$sz_cor = round(apply(mat_fg, 1, function(x) { cor(x, ctot) }),3)
+		gene_stat$sz_cor = round(.sparse_row_cor(mat_fg, colSums(mat)),3)
 	}
 
 	tot_ord = order(gene_stat$tot)
@@ -202,6 +203,19 @@ scm_gene_stat = function(mat_id,
 	cat("..done\n")
 
 	return(gene_stat)
+}
+
+# Pearson correlation of every matrix row with y, without densifying.
+# ponytail: sums-of-products formula - apply(sparse_mat, 1, cor) coerces the
+# whole matrix to dense (genes x 50k cells x 8B = multi-GiB) and OOMs.
+.sparse_row_cor = function(mat_use, y)
+{
+	n = length(y)
+	sx = Matrix::rowSums(mat_use)
+	sxx = Matrix::rowSums(mat_use * mat_use)
+	sxy = as.vector(mat_use %*% y)
+	den = sqrt((sxx - sx^2/n) * (sum(y*y) - sum(y)^2/n))
+	ifelse(den > 0, (sxy - sx*sum(y)/n)/den, NA_real_)
 }
 
 


### PR DESCRIPTION
Fixes #98.

## Chunking

`quant` was `ceiling(nrow(mat_fg)/mc_cores)`, so the gene chunk size grew as `mc_cores` shrank. Each chunk densified three matrices (`mat_fg`, `mat_ds`, `mat_n`) at `quant x n_cells x 8B` each, multiplied by every fork.

Now chunks on a fixed ~50MB dense block, so peak memory per fork is independent of `mc_cores`. Fixed-size chunks can leave a 1-gene tail, so the three row subsets use `drop=FALSE`.

I did not cap the workers at 3 as the issue suggests - `mc_cores` is the user's setting, and with 50MB blocks the cap isn't needed.

## sz_cor

`apply(mat_fg[,subs], 1, cor)` coerces the whole sparse submatrix to dense. Replaced with `.sparse_row_cor`, a sums-of-products Pearson using one sparse matvec, no densification. Chose this over chunking the `apply` because it also removes a per-gene sort over all cells.

## Verification

Golden-master: `gene_stat` is `identical()` to the previous implementation on

| case | shape | exercises |
|---|---|---|
| small | 800 x 20,000 | chunk count changes 4 -> 3 |
| wide | 300 x 50,001 | the `>50000` sz_cor branch |
| tail | 313 x 20,000 | 1-gene tail chunk |

`.sparse_row_cor` also matches `apply(mat, 1, cor)` to 3 decimals including the zero-variance -> `NA` case. Not covered: the OOM itself at 80k cells, which needs the real dataset.

## Not done

A fully sparse `stat_on_genes` (via `sparseMatrixStats`) would remove the densification and the parallelism entirely, and retire the recurring parallel-chunking bug family (#71, #37, #96). That's a refactor with a new Bioconductor dependency, out of scope for a bug fix here.

https://claude.ai/code/session_01MFLoUB1VZFB5qRNYR6BxVL